### PR TITLE
Lidor/Animatable-Data-Redeclaration

### DIFF
--- a/Sources/AnimatableMacroTests/AnimatableMacroTestCases.swift
+++ b/Sources/AnimatableMacroTests/AnimatableMacroTestCases.swift
@@ -90,6 +90,39 @@ struct AnimatableMacroTestCases {
         }
     }
     
+    @Test("Error 'VectorArithmetic' Invalid Redeclaration")
+    func testAnimatableMacroErrorAnimatableDataPropertyRedeclaration() throws {
+        assertMacro(["Animatable" : AnimatableMacro.self]) {
+            """
+            @Animatable
+            struct InvalidRedeclaration: Shape {
+                var float: CGFloat
+                func path(in rect: CGRect) -> Path { Path() }
+                    
+                var animatableData: CGFloat {
+                    get { return myValue }
+                    set { myValue = newValue }
+                }
+            } 
+            """
+        } diagnostics: {
+            """
+            @Animatable
+            ┬──────────
+            ╰─ 🛑 @Animatable automatically generates the `animatableData` property. Please remove your custom `animatableData` declaration to avoid conflicts.
+            struct InvalidRedeclaration: Shape {
+                var float: CGFloat
+                func path(in rect: CGRect) -> Path { Path() }
+                    
+                var animatableData: CGFloat {
+                    get { return myValue }
+                    set { myValue = newValue }
+                }
+            } 
+            """
+        }
+    }
+    
     //MARK: - Warnings
     @Test("Warning Redundant Usage")
     func testAnimatableMacroWarningForStructWithoutStoredProperties() throws {

--- a/Sources/TODOs.md
+++ b/Sources/TODOs.md
@@ -1,0 +1,6 @@
+# TODO
+
+- Support ```Animatable``` instead of ```Shape```
+- Refactor ```AnimatableMacro.Constants.ErrorMessage``` to ```enum``` instead of a ```struct```
+- Add ```Utilities.AnimatableDeclBuilder.validate() throws -> DeclSyntax``` function to ```throw``` an error if the builder result is mismatch
+- Write tests to all modules


### PR DESCRIPTION
- Modify AnimatableMacro
	- Modify expansion(_:_:_:) throws -> [DeclSyntax]
	 - Modify Constants
		- Add cgFloatTrimmedDescription
		- Add doubleTrimmedDescription
		- Add animatableData
		- Modify ErrorMessage
			- Add animatableDataRedeclaration
- Modify AnimatableMacroTestCases
	- Add testAnimatableMacroErrorAnimatableDataPropertyRedeclaration() throws
- Add TODOs.md